### PR TITLE
use apk add -U to skip separate apk update step

### DIFF
--- a/src/engine/container.rs
+++ b/src/engine/container.rs
@@ -205,12 +205,7 @@ impl ContainerEngine {
         if !self.opts.packages.is_empty() {
             info!("installing {} package(s)...", self.opts.packages.len());
             info!("requested packages: {}", self.opts.packages.join(", "));
-            let _update_status = Command::new("/sbin/apk")
-                .env_clear()
-                .arg("update")
-                .spawn()?
-                .wait()?;
-            let mut install_args = vec!["add"];
+            let mut install_args = vec!["add", "-U"];
             for pkg in &self.opts.packages {
                 install_args.push(pkg);
             }


### PR DESCRIPTION
neat project :)

this PR switches the way apk add is invoked to allow the `apk update` step to be skipped.
we might also want to look at --no-cache but that requires some testing.

you might also want to look into using apk-tools directly to build the minirootfs, [apko](https://github.com/chainguard-dev/apko) kind of shows how this works.  i would be happy to walk you through it.